### PR TITLE
Directions seem to ask you to paste this verbatim

### DIFF
--- a/tutorial/part3-displaying-posts/understanding-the-frontity-state.md
+++ b/tutorial/part3-displaying-posts/understanding-the-frontity-state.md
@@ -90,6 +90,9 @@ You can learn more about the `<Switch>` component [in our docs](https://docs.fro
 
 ```jsx
 // File: /packages/my-first-theme/src/components/index.js
+import React from "react"
+import { connect } from "frontity"
+import Link from "@frontity/components/link"
 import Switch from "@frontity/components/switch"
 
 const Root = ({ state }) => {
@@ -117,6 +120,8 @@ const Root = ({ state }) => {
     </>
   )
 }
+
+export default connect(Root)
 ```
 
 Since we don't yet have any links to any posts the second condition will never be satisfied, so we won't ever see the text "This is a post" come up. Let's go on to address that.


### PR DESCRIPTION
Since the previous snippets are complete, it's a little misleading thinking we can just paste this into our /components/index.js file and have this work.

Either it should be exhaustive like I'm suggesting, or have ellipses to indicate content that precedes and follows.