### PR TITLE
Update the 'Guide to the documentation' section with more learning resources

### DIFF
--- a/tutorial/part9-next-steps/guide-to-the-documentation.md
+++ b/tutorial/part9-next-steps/guide-to-the-documentation.md
@@ -1,9 +1,40 @@
-# Guide to the documentation
+# Learning resources
+
+Here's a list of the resources that are currently available to help you learn more about Frontity. They can be found in the [Learn Frontity](https://frontity.org/learn/) page too.
+
+## Documentation
 
 There are three parts to the Frontity documentation.
 
 **[tutorial.frontity.org](https://tutorial.frontity.org/)** is the introductory step-by-step tutorial which you've just completed. Yay! 🙌
 
-**[docs.frontity.org](https://docs.frontity.org/)** is our generic documentation with the Getting Started and other guides, articles introducing core concepts, description of the framework architecture, etc...
+**[docs.frontity.org](https://docs.frontity.org/)** is the generic documentation and where you should go if you want to deepen your conceptual understanding of how Frontity works and how a Frontity project should be implemented. As well as theoretical information, such as Frontity Architecture and Core Concepts, you can find many practical guides here.
 
-**[api.frontity.org](https://api.frontity.org/)** is the API reference. Once you've got the basics and the core concepts of working with Frontity nailed this is where you'll find detailed technical descriptions for the CLI, packages and plugins available in Frontity.
+**[api.frontity.org](https://api.frontity.org/)** is the API reference. Once you've got the basics and the core concepts of working with Frontity nailed this is where you'll find detailed technical descriptions for the CLI and plugins available in Frontity. This is also the place where you should go if you want to learn more about the different Frontity packages, including themes.
+
+## Demos
+
+On this [**GitHub repository**](https://github.com/frontity-demos/frontity-examples) there's a number of example projects each of which is intended to demonstrate how to achieve a particular task using Frontity. Some of the most popular projects are:
+
+- [Custom Post Types](https://github.com/frontity-demos/frontity-examples/blob/master/custom-post-types/README.md)
+- [Fetching a Menu from WordPress](https://github.com/frontity-demos/frontity-examples/blob/master/fetch-menu-from-wp/README.md)
+- [Contact Form in Footer](https://github.com/frontity-demos/frontity-examples/blob/master/contact-form/README.md)
+
+## Videos
+
+If videos are more your thing, there are a few playlists on [**Frontity's Youtube channel**](https://www.youtube.com/c/Frontity/) which will help you to jump in and get coding with Frontity, including:
+
+- [Frontity Talks](https://youtube.com/playlist?list=PLC9teX20GdrTBeOzSwE-bFW-MbBEUwowS): a series of videos where the Frontity DevRel team explain a variety of different topics related to the framework.
+- [Demos](https://youtube.com/playlist?list=PLC9teX20GdrSWiQ5wOzDnLySxC66yz3yg): a series of demos to help you understand how to use specific features in your project.
+
+## Blog posts
+
+Other development posts, as well as case studies and general news, can be found in the [**Frontity blog**](https://frontity.org/blog/). Here's some that you might find interesting:
+
+- [Connecting Gutenberg and Frontity](https://frontity.org/blog/connecting-gutenberg-and-frontity/)
+- [How to use Frontity with SpinupWP](https://frontity.org/blog/how-to-use-frontity-with-spinupwp/)
+- [Diariomotor Case Study](https://frontity.org/blog/diariomotor-case-study/)
+
+## Showcase
+
+Do you need some inspiration for your project? The Frontity community is always building amazing websites. You can discover some of them in the [**Showcase**](https://frontity.org/showcase/) page.

--- a/tutorial/part9-next-steps/showcases.md
+++ b/tutorial/part9-next-steps/showcases.md
@@ -1,9 +1,0 @@
-# Showcases
-
-<p>
-  <img alt="Frontity showcases" src="https://frontity.org/wp-content/uploads/2021/04/frontity-tutorial-part9img1.png" width="800">
-</p>
-
-We have a [showcases](https://frontity.org/showcase/) page where we feature interesting or attractive projects built with Frontity. These projects are created by the community of developers that use Frontity, developers such as yourself.
-
-Your project could be featured here. [Submit your project](https://docs.google.com/forms/d/e/1FAIpQLSe1yNVt-CP6zbGzfltIIu3Vj5eLFAjHpd_6qaZOuVpGUurh4g/viewform), we'd love to see it, and look forward to featuring it in our showcase page.


### PR DESCRIPTION
I've suggested replacing the "Guide to the documentation" title with the "Learning Resources" one, and added more content to this section. Instead of providing users with just an overview of the docs, I think it makes sense to share more information about the available learning materials (and add a link to the `Learn` page), so that users that land directly in the tutorial can find them easily. Please feel free to review it and ensure that you’re happy with these changes.