### PR TITLE
Update add-support-for-cpts.md

### DIFF
--- a/tutorial/part6-custom-post-types/add-support-for-cpts.md
+++ b/tutorial/part6-custom-post-types/add-support-for-cpts.md
@@ -40,6 +40,8 @@ Learn more in [the docs for @frontity/wp-source](https://docs.frontity.org/api-r
 
 Frontity now knows about this CPT and will just work with it. Try it! Enter `localhost:3000/destinations` into your browser's address bar and you should see a listing of our favourite travel destinations. Click on one and it displays using the `<Post>` component.
 
+{% hint style="info" %} **Note** that the 'show_in_rest' parameter needs to be set to true in the `register_post_type()` function to include the CPTs in the REST API. {% endhint %}
+
 **And that's it** - that's all we need to do to have our project use WordPress CPTs!
 
 However, in the case of this CPT we don't want to display the author and date information so let's tell our `<Root>` component to use the `<Page>` component instead for this post type.


### PR DESCRIPTION
I have added a note to ensure that the 'show_in_rest' parameter in the `register_post_type()` function is set to true in order for CPTs to show in the REST API.  This can be very helpful for developers that don't have in depth experience with wordpress and are wondering why they are getting an error when attempting to access their CPT endpoints. 